### PR TITLE
Nested variants use pointers

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aphoh/go-substrate-gen/typegen"
 )
 
+const VERSION = "0.7.0"
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Printf("%v\n", err.Error())
@@ -22,6 +24,14 @@ func main() {
 
 func run() error {
 	args := os.Args[1:]
+	// check for --version / -v
+	for _, arg := range args {
+		if arg == "-v" || arg == "--version" {
+			fmt.Printf("go-substrate-gen version %s\n", VERSION)
+			return nil
+		}
+	}
+
 	if len(args) < 2 {
 		return fmt.Errorf("expected two arguments (json path, package name)")
 	}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aphoh/go-substrate-gen/typegen"
 )
 
-const VERSION = "0.7.0"
+const VERSION = "0.8.0"
 
 func main() {
 	if err := run(); err != nil {

--- a/typegen/composite.go
+++ b/typegen/composite.go
@@ -44,7 +44,7 @@ func (tg *TypeGenerator) GenComposite(v *types.Si1TypeDefComposite, mt *types.Po
 	for i, field := range v.Fields {
 		code = append(code, jen.Comment(fmt.Sprintf("Field %d with TypeId=%v", i, field.Type.Int64())))
 		// Turns out composites don't have unique names... sob
-		gf, err := tg.fieldCode(field, "", "", false)
+		gf, err := tg.fieldCode(field, "", "", false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func (tg *TypeGenerator) GenComposite(v *types.Si1TypeDefComposite, mt *types.Po
 		cnt := fNameCounts[gf.Name]
 		if cnt > 1 {
 			// Name already exists, generate a new one with a postfix
-			gf, err = tg.fieldCode(field, "", fmt.Sprint(cnt-1), false)
+			gf, err = tg.fieldCode(field, "", fmt.Sprint(cnt-1), false, false)
 			if err != nil {
 				return nil, err
 			}
@@ -76,7 +76,7 @@ type GenField struct {
 }
 
 // Generate and return a struct field
-func (tg *TypeGenerator) fieldCode(f types.Si1Field, prefix, postfix string, useTypeName bool) (*GenField, error) {
+func (tg *TypeGenerator) fieldCode(f types.Si1Field, prefix, postfix string, useTypeName bool, forcePointer bool) (*GenField, error) {
 	var fieldName string
 	if f.Name != "" {
 		fieldName = string(f.Name)
@@ -101,7 +101,7 @@ func (tg *TypeGenerator) fieldCode(f types.Si1Field, prefix, postfix string, use
 
 	// Add the field
 	// If it's a rust pointer, use a pointer to avoid recursive structs
-	isPtr := strings.HasPrefix(string(f.TypeName), "Box") || strings.HasPrefix(string(f.TypeName), "alloc::boxed::Box") || strings.HasPrefix(string(f.TypeName), "OpaqueCall")
+	isPtr := strings.HasPrefix(string(f.TypeName), "Box") || strings.HasPrefix(string(f.TypeName), "alloc::boxed::Box") || strings.HasPrefix(string(f.TypeName), "OpaqueCall") || forcePointer
 	if isPtr {
 		code = append(code, jen.Id(fieldName).Op("*").Custom(utils.TypeOpts, fieldTy.Code()))
 	} else {


### PR DESCRIPTION
Nested variants now use pointers, which makes the RuntimeCall and
RuntimeEvent structs substantially smaller, most likely by 80-95%,
depending on the number and complexity of pallets in the runtime.

This has all been tested roughly, both submitting calls, and decoding structures.

Resolves #3. 

(Also please do not squash-merge, as I already tagged the commit as v0.8.0)